### PR TITLE
Format times on booking instances

### DIFF
--- a/lib/openlive/booking.rb
+++ b/lib/openlive/booking.rb
@@ -8,6 +8,20 @@ module Openlive
       self.class.delete(id)
     end
 
+    # Return time object for start time
+    #
+    # @return [Time]
+    def start
+      Time.parse(api_data[:start])
+    end
+
+    # Return time object for finish time
+    #
+    # @return [Time]
+    def finish
+      Time.parse(api_data[:finish])
+    end
+
     class << self
       # Find and return a booking record
       #
@@ -54,6 +68,9 @@ module Openlive
 
       private
 
+      # Called when creating a booking on OpenLIVE API
+      #
+      # @return [Hash]
       def format_attributes(attributes)
         attributes.update(attributes) do |key, val|
           if val.is_a?(Time) || val.is_a?(DateTime)

--- a/spec/openlive/booking_spec.rb
+++ b/spec/openlive/booking_spec.rb
@@ -2,14 +2,31 @@ require 'spec_helper'
 
 describe Openlive::Booking do
   describe "instance methods" do
+    let(:booking) do
+      Openlive::Booking.new({
+        "id" => "test",
+        "start" => Time.now.strftime("%Y-%m-%dT%H:%M:%S.%LZ"),
+        "finish" => (Time.now + 4.hours).strftime("%Y-%m-%dT%H:%M:%S.%LZ")
+      })
+    end
+
     describe "#delete" do
-      let(:booking) { Openlive::Booking.new({ "id" => "test" }) }
       before { allow(Openlive::Booking).to receive(:delete) { true } }
       after { booking.delete }
 
       it "calls the class delete method with the ID" do
         expect(Openlive::Booking).to receive(:delete).with("test")
       end
+    end
+
+    describe "#start" do
+      subject { booking.start }
+      it { is_expected.to be_a(Time) }
+    end
+
+    describe "#finish" do
+      subject { booking.finish }
+      it { is_expected.to be_a(Time) }
     end
   end
 


### PR DESCRIPTION
Rather than returning strings, return Time objects so that they don't
need to be parsed elsewhere.